### PR TITLE
Fix the exchangeApdu command used by getFirmwareVersion.

### DIFF
--- a/src/com/btchip/BTChipDongle.java
+++ b/src/com/btchip/BTChipDongle.java
@@ -324,8 +324,21 @@ public class BTChipDongle implements BTChipConstants {
 		System.arraycopy(data, 0, apdu, 5, data.length);
 		return exchangeCheck(apdu, acceptedSW);
 	}
+
+	private byte[] exchangeApdu(byte cla, byte ins, byte p1, byte p2, int acceptedSW[]) throws BTChipException {
+		byte[] apdu = new byte[4];
+		apdu[0] = cla;
+		apdu[1] = ins;
+		apdu[2] = p1;
+		apdu[3] = p2;
+		return exchangeCheck(apdu, acceptedSW);
+	}
 	
 	private byte[] exchangeApdu(byte cla, byte ins, byte p1, byte p2, int length, int acceptedSW[]) throws BTChipException {
+		if(length == 0) {
+			return exchangeApdu(cla, ins, p1, p2, acceptedSW);
+		}
+
 		byte[] apdu = new byte[5];
 		apdu[0] = cla;
 		apdu[1] = ins;


### PR DESCRIPTION
This fixes the issue where getFirmwareVersion calls exchangeApdu with length 0. Length 0 means that the smartcard should receive two other length bytes (so one can specify an apdu length of up to 2^16-1).

Since we do not send these bytes the getFirmwareVersion command (and probably others) will fail with 0x6700 SW_WRONG_LENGTH.

Note that I have not spent time on tracking down all the instances where the original exchangeApdu is called with length 0, which is why i've simply 'shimmed' the original method to call my method when length is 0. This is probably not the best solution.